### PR TITLE
Change optional hash transforms to produce nil valued key

### DIFF
--- a/lib/morpher/transform.rb
+++ b/lib/morpher/transform.rb
@@ -350,11 +350,16 @@ module Morpher
         transform_keys(required, input)
       end
 
+      def defaults
+        optional.map(&:value).product([nil]).to_h
+      end
+      memoize :defaults
+
       def transform_optional(input)
         transform_keys(
           optional.select { |key| input.key?(key.value) },
           input
-        )
+        ).fmap(&defaults.public_method(:merge))
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/spec/unit/morpher/record_spec.rb
+++ b/spec/unit/morpher/record_spec.rb
@@ -8,22 +8,40 @@ RSpec.describe Morpher::Record do
       host.class_eval { include instance }
     end
 
-    let(:host)           { Class.new                                 }
-    let(:host_instance)  { host.new(attributes)                      }
-    let(:instance)       { described_class.new(attributes_transform) }
-    let(:attributes)     { { a: 'foo', b: 10 }                       }
+    let(:attributes)     { { a: 'foo', b: 10, c: nil } }
+    let(:host)           { Class.new                   }
+    let(:host_instance)  { host.new(attributes)        }
 
-    let(:attributes_transform) do
+    let(:instance) do
+      described_class.new(
+        required: required_transform,
+        optional: optional_transform
+      )
+    end
+
+    let(:required_transform) do
       {
         a: Morpher::Transform::Primitive.new(String),
         b: Morpher::Transform::Primitive.new(Integer)
       }
     end
 
-    let(:expected_keys_transform) do
+    let(:optional_transform) do
+      {
+        c: Morpher::Transform::Boolean.new
+      }
+    end
+
+    let(:expected_required_keys_transform) do
       [
-        Morpher::Transform::Hash::Key.new(:a, attributes_transform.fetch(:a)),
-        Morpher::Transform::Hash::Key.new(:b, attributes_transform.fetch(:b))
+        Morpher::Transform::Hash::Key.new(:a, required_transform.fetch(:a)),
+        Morpher::Transform::Hash::Key.new(:b, required_transform.fetch(:b))
+      ]
+    end
+
+    let(:expected_optional_keys_transform) do
+      [
+        Morpher::Transform::Hash::Key.new(:c, optional_transform.fetch(:c))
       ]
     end
 
@@ -55,7 +73,10 @@ RSpec.describe Morpher::Record do
           [
             Morpher::Transform::Primitive.new(Hash),
             Morpher::Transform::Hash::Symbolize.new,
-            Morpher::Transform::Hash.new(required: expected_keys_transform, optional: []),
+            Morpher::Transform::Hash.new(
+              required: expected_required_keys_transform,
+              optional: expected_optional_keys_transform
+            ),
             Morpher::Transform::Success.new(host.method(:new))
           ]
         )

--- a/spec/unit/morpher/transform/hash_spec.rb
+++ b/spec/unit/morpher/transform/hash_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Morpher::Transform::Hash do
           let(:input) { {} }
 
           it 'returns success' do
-            expect(apply).to eql(right(input))
+            expect(apply).to eql(right(foo: nil))
           end
         end
 


### PR DESCRIPTION
* This also changes `Morpher:::Record` to accept separate `required` an
  `optional` kwargs.