### PR TITLE
Add Morpher::Transform#to_proc

### DIFF
--- a/lib/morpher/transform.rb
+++ b/lib/morpher/transform.rb
@@ -43,6 +43,13 @@ module Morpher
       Maybe.new(self)
     end
 
+    # Build Proc to transform input
+    #
+    # @return [Proc]
+    def to_proc
+      public_method(:call).to_proc
+    end
+
     # Deep error data structure
     class Error
       include Anima.new(

--- a/spec/unit/morpher/transform_spec.rb
+++ b/spec/unit/morpher/transform_spec.rb
@@ -40,4 +40,23 @@ RSpec.describe Morpher::Transform do
       )
     end
   end
+
+  describe '#to_proc' do
+    subject do
+      Morpher::Transform::STRING
+    end
+
+    it 'returns proc' do
+      expect(subject.to_proc).to be_instance_of(Proc)
+    end
+
+    it 'executes #call when evaluated' do
+      aggregate_failures do
+        expect(subject.to_proc.call('a').from_right).to be('a')
+        expect(subject.to_proc.call(1).lmap(&:compact_message).from_left).to eql(
+          'String: Expected: String but got: Integer'
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This branch allows #to_proc to be called on any transformer, which will allow
some common expressions to be simplified.

## Changes

- Add Morpher::Transform#to_proc
